### PR TITLE
content: remove duplicate body h1 from 17 articles

### DIFF
--- a/src/content/articles/building-connected-communities-data-integration.mdx
+++ b/src/content/articles/building-connected-communities-data-integration.mdx
@@ -14,8 +14,6 @@ lastUpdated: "2025-01-27"
 readingTime: 15
 ---
 
-# Building Connected Communities: Leveraging Data Integration for Personalized Engagement
-
 The ability to effectively integrate customer and community data has become a critical skill. Today's digital ecosystems are complex, with members interacting across multiple platforms—from learning management systems to social media and community forums. Without a unified view of these interactions, it's challenging to fully understand your community members and engage them meaningfully.
 
 ## Table of Contents

--- a/src/content/articles/compressed-nfts-poap-case-study.mdx
+++ b/src/content/articles/compressed-nfts-poap-case-study.mdx
@@ -14,8 +14,6 @@ status: "published"
 author: "Opeyemi Stephen"
 ---
 
-# Compressed NFTs in Production: A Campus Tour Case Study
-
 520 students attended the Solana Students Africa Campus Tour. We visited five Nigerian universities (University of Lagos, Federal University of Agriculture Abeokuta, University of Uyo, Olabisi Onabanjo University, and University of Abuja) over several weeks in the last quarter of 2025. They learned to build on Solana. Some just attended. Others actually shipped programs on-chain.
 
 We wanted to give them something permanent. Not a PDF certificate that lives in a forgotten email folder. Not a LinkedIn badge. Real, on-chain credentials they own forever. Stored on Solana, verifiable by anyone, and portable to wherever they go next.

--- a/src/content/articles/corporate-l1s-africa-payments.mdx
+++ b/src/content/articles/corporate-l1s-africa-payments.mdx
@@ -14,8 +14,6 @@ lastUpdated: "2025-08-18"
 readingTime: 12
 ---
 
-# When Payments Own the Base Layer: What Corporate L1s Mean for L2s — and for Africa v2.0
-
 A founder described today as "9/11 for L2s." I don't endorse that phrasing, but I get the sentiment: when **payments companies start owning the base layer**, incentives and gravity change. **Circle** is bringing USDC into the substrate with **Arc**; **Fortune** says **Stripe** is quietly building **Tempo**. This isn't "just another chain." It's a bid to **vertically integrate settlement**, fees, FX, and compliance in one place.
 
 In other words, the companies that move money want to own the road, not just drive on it.

--- a/src/content/articles/education-first-developer-community.mdx
+++ b/src/content/articles/education-first-developer-community.mdx
@@ -14,8 +14,6 @@ draft: false
 status: "published"
 ---
 
-# Building an Education-First Developer Community: A Comprehensive Guide to Engaging and Empowering Learners
-
 Today, communities are no longer just a gathering of enthusiasts or consumers. They've become hubs of learning, innovation, and professional growth—especially in developer circles. But the secret to building a successful, engaged community goes beyond just having active members. It starts with an **education-first approach**.
 
 Focusing on **educating your community** transforms the experience. You shift from being a provider of content to being a trusted source of knowledge and growth. And when people feel they're gaining real, practical value, they stick around. This article will dive into how to build an education-first developer community, with real-life examples to guide you along the way. We'll walk through key strategies, best practices, and the steps you can take to create a thriving learning hub.

--- a/src/content/articles/ethereum-l2-reckoning.mdx
+++ b/src/content/articles/ethereum-l2-reckoning.mdx
@@ -14,9 +14,6 @@ status: "published"
 author: "Opeyemi Stephen"
 ---
 
-
-# The Reckoning: How Ethereum's Biggest Bet Unraveled and What Comes Next
-
 *Vitalik admitted Ethereum's L2 roadmap failed. Here's the six-year arc, the technical fix, and what nobody's talking about.*
 
 *This story has ten acts. It spans six years, two competing philosophies, a $250 billion ecosystem, and one post that rewrote the rules. Dim the lights and settle in, let's watch the movie.*

--- a/src/content/articles/flutterwave-mono-analysis.mdx
+++ b/src/content/articles/flutterwave-mono-analysis.mdx
@@ -14,9 +14,6 @@ status: "published"
 author: "Opeyemi Stephen"
 ---
 
-
-# Beyond the Headlines: What the Flutterwave-Mono Deal Really Means for African Fintech
-
 *An analysis of payments, data, and the battle for Africa's financial infrastructure*
 
 ## Introduction

--- a/src/content/articles/html-pattern-attribute-guide.mdx
+++ b/src/content/articles/html-pattern-attribute-guide.mdx
@@ -14,8 +14,6 @@ draft: false
 status: "published"
 ---
 
-# [Underrated] - The Pattern Attribute
-
 The `pattern` attribute in HTML allows you to define a **regular expression (regex)** that the input value must match. It's a way to validate user input on the client side without needing JavaScript.
 
 ## How Does It Work?

--- a/src/content/articles/javascript-expressions-statements.mdx
+++ b/src/content/articles/javascript-expressions-statements.mdx
@@ -14,8 +14,6 @@ draft: false
 status: "published"
 ---
 
-# The Difference Between an Expression and a Statement in JavaScript and React
-
 To deeply understand the distinction between **expressions** and **statements**, let's break it down step-by-step with relatable examples and clear explanations.
 
 ## What is an Expression?

--- a/src/content/articles/javascript-rest-spread-guide.mdx
+++ b/src/content/articles/javascript-rest-spread-guide.mdx
@@ -14,8 +14,6 @@ draft: false
 status: "published"
 ---
 
-# Mastering Rest and Spread Operators in JavaScript and React: A Complete Guide
-
 ## Introduction
 
 In modern JavaScript and React development, two powerful tools often go overlooked: **rest** and **spread** operators. Though they might seem small in terms of syntax, these two operators can significantly simplify your code, improve readability, and make your applications more flexible.

--- a/src/content/articles/react-component-instances.mdx
+++ b/src/content/articles/react-component-instances.mdx
@@ -14,8 +14,6 @@ draft: false
 status: "published"
 ---
 
-# Inside the Mind of React: Demystifying Component Instances
-
 React is more than just a library for building user interfaces; it's a tool for creating scalable, efficient, and interactive applications. Central to React's operation is the concept of **component instances**, the mechanisms that allow React to manage state, props, and lifecycles effectively.
 
 In this guide, we'll explore React component instances in detail, with explanations, real-world analogies, advanced examples, and actionable insights to ensure you can build robust applications confidently.

--- a/src/content/articles/react-composition-patterns.mdx
+++ b/src/content/articles/react-composition-patterns.mdx
@@ -14,8 +14,6 @@ draft: false
 status: "published"
 ---
 
-# Composition in React: The Art of Reusable Components
-
 You've built your fifth modal. You copy-paste the same logic… again. The state management, the backdrop click handling, the escape key listener. It's working, but something feels off. You know there's a better way.
 
 This is where composition patterns shine. They're not only techniques, they're a mindset shift from "how do I build this component?" to "how do I build components that work together?"

--- a/src/content/articles/react-dynamic-state-management.mdx
+++ b/src/content/articles/react-dynamic-state-management.mdx
@@ -14,8 +14,6 @@ draft: false
 status: "published"
 ---
 
-# Dynamic State Management in React: Building a Gradient Generator Tool
-
 Think about a time you used a design tool like Canva. As you played around with gradients—adding, tweaking, and removing colors—the interface felt effortless. This seamless interaction relies on robust state management principles.
 
 In this article, we'll explore **dynamic state management** in React by creating a gradient generator tool. Step by step, you'll understand how to:

--- a/src/content/articles/react-hooks-complete-guide.mdx
+++ b/src/content/articles/react-hooks-complete-guide.mdx
@@ -14,8 +14,6 @@ draft: false
 status: "published"
 ---
 
-# React Hooks Complete Guide: Master State Management and Side Effects
-
 React Hooks have revolutionized the way we build React applications. No longer confined to class components, functional components can now handle state, side effects, context, and much more. This guide explores every facet of React Hooks—from basic to advanced—and illustrates how they solve everyday problems in modern web development.
 
 ## Introduction

--- a/src/content/articles/react-immutability-guide.mdx
+++ b/src/content/articles/react-immutability-guide.mdx
@@ -14,8 +14,6 @@ draft: false
 status: "published"
 ---
 
-# React Immutability: Complete Guide for State Management
-
 ## Introduction
 
 Picture this: You're building a React app, and suddenly your UI stops updating even though you're sure you changed the state. Sound familiar? This frustrating scenario happens to countless developers who unknowingly violate one of React's core principles: **immutability**.

--- a/src/content/articles/react-lifting-state-up.mdx
+++ b/src/content/articles/react-lifting-state-up.mdx
@@ -14,8 +14,6 @@ draft: false
 status: "published"
 ---
 
-# Mastering State Management in React: The Power of Lifting State Up
-
 State management is one of the most essential yet challenging aspects of React development. For beginners and experienced developers alike, understanding **how to effectively manage shared state** is key to building scalable and maintainable UIs. This is where the concept of **lifting state up** becomes a game-changer.
 
 In this guide, we'll take an in-depth look at lifting state in React, explore its benefits, and discuss how to recognize and implement it in real-world scenarios.

--- a/src/content/articles/react-props-state-guide.mdx
+++ b/src/content/articles/react-props-state-guide.mdx
@@ -14,8 +14,6 @@ draft: false
 status: "published"
 ---
 
-# Understanding Props and State in React: A Beginner's Guide
-
 ## 1. Introduction
 
 React is a JavaScript library used for building user interfaces, especially single-page applications. One of the main reasons React is so popular is because of its **component-based architecture** and **declarative nature**.

--- a/src/content/articles/react-useref-complete-guide.mdx
+++ b/src/content/articles/react-useref-complete-guide.mdx
@@ -14,8 +14,6 @@ draft: false
 status: "published"
 ---
 
-# Mastering useRef in React: A Deep Dive into Its Practical Uses
-
 React's `useRef` is one of those hooks that developers often struggle to understand at first. Unlike `useState` and `useEffect`, it doesn't seem as intuitive. Why do we need a hook that doesn't trigger re-renders? What problems does it solve in real-world applications?
 
 This article provides an **in-depth look at `useRef`**, explaining **why it exists, how it works, and when to use it effectively**. By the end, you'll not only understand `useRef` but also know how to leverage it in practical applications to improve your React development workflow.


### PR DESCRIPTION
Every article page renders the frontmatter title as the page h1 (BlogPostClient), and 17 articles also opened their MDX body with a `# Title` heading, producing two h1 elements per page. In 14 of them the body h1 was an older narrative title that no longer matched the frontmatter title, so those pages were visibly showing two different titles stacked.

This removes the leading body h1 from all 17 (pure deletions, prose untouched). The other 16 articles never had one.

Verify: `npm run build`, then every page under `.next/server/app/blog/*.html` contains exactly one `<h1` (checked: all 34 pass).