### PR TITLE
content: rename llm article slug to ai-agent-vs-function-crewai

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,15 @@ const nextConfig = {
   reactStrictMode: true,
   outputFileTracingRoot: __dirname,
   transpilePackages: ['next-mdx-remote'],
+  async redirects() {
+    return [
+      {
+        source: '/blog/llm-in-the-wrong-place-twice',
+        destination: '/blog/ai-agent-vs-function-crewai',
+        permanent: true,
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: 'res.cloudinary.com' },

--- a/src/content/articles/ai-agent-vs-function-crewai.mdx
+++ b/src/content/articles/ai-agent-vs-function-crewai.mdx
@@ -1,12 +1,12 @@
 ---
 title: "When Your AI Agent Should Just Be a Function: Lessons from a CrewAI Pipeline"
-slug: "llm-in-the-wrong-place-twice"
+slug: "ai-agent-vs-function-crewai"
 date: "2026-06-11"
 excerpt: "Lessons from a CrewAI multi-agent app: two agents that should have been functions, an XSS hole in a framework default, and prompt bugs no test catches."
 tags: ["LLM", "AI Agents", "CrewAI", "Python", "Case Study"]
 featured: true
 coverImage: "https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1781179075/Screenshot_2026-06-11_at_12.41.49_PM_y2siep.png"
-canonicalUrl: "https://www.opeyemibangkok.com/blog/llm-in-the-wrong-place-twice"
+canonicalUrl: "https://www.opeyemibangkok.com/blog/ai-agent-vs-function-crewai"
 readingTime: 11
 lastUpdated: "2026-06-12"
 draft: false

--- a/src/content/blog.config.ts
+++ b/src/content/blog.config.ts
@@ -1,5 +1,5 @@
 export const popularSlugs = [
-  'llm-in-the-wrong-place-twice',
+  'ai-agent-vs-function-crewai',
   'ethereum-l2-reckoning',
   'react-hooks-complete-guide',
   'compressed-nfts-poap-case-study',


### PR DESCRIPTION
Aligns the URL with the retitled article before syndication locks it in. Old path 308-redirects via next.config.mjs (verified against next start: old path 308, new path 200).