### PR TITLE
content: publish the-off-ramp-is-still-the-product

### DIFF
--- a/src/content/articles/the-off-ramp-is-still-the-product.mdx
+++ b/src/content/articles/the-off-ramp-is-still-the-product.mdx
@@ -1,0 +1,87 @@
+---
+title: "The Off-Ramp Is Still the Product: Reading Flutterwave × Circle Like an Operator"
+date: "2026-07-14"
+excerpt: "Ripple and Circle both bought into Flutterwave within thirty days. The receipts say the real story is the off-ramp, not the chain: an operator's guide to reading Africa's stablecoin announcements."
+slug: "the-off-ramp-is-still-the-product"
+readingTime: 12
+tags: ["Stablecoins", "African Fintech", "Payments", "Flutterwave", "Web3"]
+author: "Opeyemi Stephen"
+coverImage: "https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1784045492/five-rails-timeline_siweub.png"
+canonicalUrl: "https://www.opeyemibangkok.com/blog/the-off-ramp-is-still-the-product"
+status: "published"
+---
+
+It's no longer news that two dollar-stablecoin issuers bought into the same African payments company within thirty days of each other, or at least were announced within that window. Ripple took equity in [Flutterwave's Series E on June 16, 2026](https://www.coindesk.com/business/2026/06/16/ripple-invests-in-flutterwave-pushing-its-stablecoin-and-xrp-ledger-into-payments-across-africa) and walked away with RLUSD named the default settlement asset across Flutterwave's stablecoin products. Circle followed on July 7, 2026: [a strategic investment of undisclosed size](https://flutterwave.com/us/blog/building-the-stablecoin-infrastructure-for-africa), plus USDC "settlement across our platform". The coverage called it a partnership and treated it like a watershed. Reading the source documents tells a stranger story: there is no Circle-side announcement, no Circle executive is quoted anywhere, no blockchain is named for the USDC leg, and USDC, the coin in every headline, isn't even Flutterwave's default stablecoin. That slot belongs to Ripple's RLUSD.
+
+So I stopped asking what Circle's money means for USDC in Africa, and started asking a different question: why does Flutterwave keep announcing settlement rails, and why can't I find a single disclosed volume number for any of them?
+
+## The partnership has one side talking
+
+This is by no means poking holes. I want it to be clear as day. Let's start with what exists on the record. On July 7, 2026, Flutterwave published [a blog post](https://flutterwave.com/us/blog/building-the-stablecoin-infrastructure-for-africa) announcing "a strategic investment from Circle Ventures and the addition of USDC settlement across our platform". No amount. No timeline, no named markets, no named licenses, and no named blockchain for the USDC leg. One clarification, because the names invite confusion: Circle is not a blockchain. It's the company that issues USDC, and USDC lives natively on a long list of chains, Ethereum to Base to Polygon, while Circle raises money to build [a chain of its own called Arc](https://www.cnbc.com/2026/05/11/circle-closes-222-million-from-blackrock-apollo-for-arc-blockchain.html). So "USDC settlement" has to land on some chain eventually, and Flutterwave hasn't said which. The only chain that appears anywhere in the post is the XRP Ledger, carrying RLUSD as the default.
+
+Circle, for its part, has said nothing about this deal. I checked again while editing this piece: nothing on its newsroom, nothing on its blog, nothing from its executives, as of July 13, 2026. Two fairness notes before I make anything of that. Circle Ventures doesn't do announcement posts; its portfolio companies announce, so the silence is normal venture behavior. And Circle's partner directory has listed Flutterwave since the Circle Payments Network launch in April 2025, so the relationship itself is acknowledged on Circle's side. What the quiet does mean is narrower and still worth saying: nobody on the issuer side has co-signed the scale of what the coverage described. An investment, yes. A co-launch, no.
+
+Every article that ran launch week reproduces the same press-release phrasing, and the one carrying the CEO's quote is [a paid placement](https://nairametrics.com/2026/07/08/flutterwave-secures-investment-from-circle-ventures-as-it-expands-usdc-payments-settlement-across-africa/): Nairametrics ran it under "NM Partners," the byline it uses for sponsored content. Olugbenga Agboola's line is that the deal "positions Flutterwave as the default stablecoin gateway for the continent". It's a good line. It is also, on the evidence so far, a wish rather than a description.
+
+None of this makes the deal fake. Circle Ventures putting money into Flutterwave is real and confirmed by the company itself. But an investment plus a settlement option is a different creature from the distribution watershed the headlines described, and the difference matters if you build on these rails for a living.
+
+## Five rails in thirty-three months
+
+Here is Flutterwave's stablecoin announcement record, assembled in one place:
+
+| Announced | Rail | The promise | What you can verify today |
+|---|---|---|---|
+| Oct 2023 | [USDC on Hedera](https://bitcoinke.io/2023/10/flutterwave-to-integrate-usdc-payments-settlements/) | Payment settlement integration | No traceable product; absent from all later announcements |
+| Oct 2025 | [Polygon](https://polygon.technology/blog/flutterwave-selects-polygon-as-its-default-blockchain-for-cross-border-payments) | "Default blockchain" for cross-border payments | Demoted to "one settlement rail" by Jun 2026; unmentioned in July's post |
+| Jun 2026 | [Tempo](https://techcabal.com/2026/06/05/flutterwave-multi-rail-stablecoin-ambitions/) | A rail alongside Polygon | Announced weeks before the Ripple deal |
+| Jun 2026 | [RLUSD on XRP Ledger](https://www.prnewswire.com/news-releases/ripple-participates-in-flutterwaves-series-e-with-strategic-investment-to-accelerate-african-stablecoin-payments-302801593.html) | Default stablecoin, enterprise settlement | Announced Jun 16, 2026; Nigeria named first market |
+| Jul 2026 | [USDC via Circle](https://flutterwave.com/us/blog/building-the-stablecoin-infrastructure-for-africa) | Settlement across the platform | Announced Jul 7, 2026; no chain, timeline, or market named |
+
+Two details in that table did not make the launch coverage. First, Flutterwave's own product blog [said in March 2026](https://flutterwave.com/us/blog/stablerails-from-internal-testing-to-real-world-use) that its stablecoin infrastructure was "live in production environments, powering internal testing, select merchant transactions, and early integrations" across NGN, GHS and USD. That is real progress and worth crediting. But the public-facing [StableRails page](https://flutterwave.com/eu/stablerails) remains a waitlist signup as of July 13, 2026, not a product with pricing and API documentation. Second, Polygon went from crowned default to quietly demoted in nine months, and I could not find a single outlet that reported why, or any evidence of volume the integration processed in between. Circle's one previous African flagship deal tells the same story: [the Onafriq pilot announced in April 2025](https://onafriq.com/press/article/onafriq-partners-with-circle-to-power-remittances) has published no results since.
+
+Read the record plainly: five rails announced in thirty-three months, two crowned "defaults," and not one disclosed volume number. Nobody here is running a fraud. But announcing a rail and operating one are different activities, and only one of them generates press releases.
+
+## The rail was never the bottleneck
+
+Sub-Saharan Africa is still the most expensive place on earth to send money to. The World Bank puts the average cost at [8.46% on a $200 remittance as of Q3 2025](https://remittanceprices.worldbank.org/sites/default/files/2026-04/RPW_main_report_and_annex_Q325.pdf), against a 6.36% global average. That number is the reason stablecoins stopped being theoretical here years ago. [Chainalysis counts roughly $205 billion](https://www.chainalysis.com/blog/subsaharan-africa-crypto-adoption-2025/) in on-chain value received in the region between July 2024 and June 2025, with stablecoins at 43% of it, and I carry the usual caveat every time I quote them: the attribution methodology is the vendor's own, and nobody independently replicates it. [The IMF puts Nigeria alone at roughly 60%](https://www.imf.org/en/news/articles/2026/06/16/stablecoins-in-nigeria) of the region's stablecoin inflows. On the street, the best reporting available says the workhorse is USDT on Tron rather than USDC on anything, though nobody has primary continent-wide numbers, so I treat every dominance claim accordingly.
+
+Notice what none of those numbers describe: a blockchain problem. Transaction fees on every chain Flutterwave has ever named run from fractions of a cent to a few cents, rounding errors against an 8.46% corridor cost. Moving the dollar token costs cents. The real cost sits at the exit, where tokens have to become naira a merchant can actually spend.
+
+![Bar comparison titled "The bar you can't see": the average corridor charge on a $200 send into Sub-Saharan Africa is $16.92 (8.46%, World Bank Q3 2025), drawn as a large bar. Moving the token on any chain Flutterwave has named costs about $0.02, drawn to scale as a hairline roughly 850 times smaller: the entire layer all five announcements are about. Below, a band lists what stands between the token and spendable naira: SEC VASP licensing and the CBN's proposed regime, banking relationships and market-maker liquidity, and a regulator who knows your name; this layer removed Binance's entire NGN business in one week in March 2024.](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1784045491/cost-stack_mxtyfy.png)
+*The bar you can't see. The announcements all live in the hairline.*
+
+Nigeria already ran this experiment for us. In March 2024, in the middle of its fight with the state over the naira's exchange rate, [Binance shut down every NGN service it operated](https://www.binance.com/en/support/announcement/binance-to-discontinue-all-nigerian-naira-ngn-services-f9857dc2fea4448ba1fb8815d87d8144). The chains kept producing blocks and the tokens kept moving, but the largest off-ramp in the country's most active crypto market disappeared inside a week and took its liquidity with it. No settlement-rail announcement touches that layer, not on Hedera, not on Polygon, not on the XRP Ledger. The off-ramp is a licensing problem, a banking-relationship problem, and a market-maker problem. The chain never gets a vote.
+
+That, I think, is the honest explanation for the pattern in the table above. Announcing a rail costs a press release. Shipping one costs naira liquidity, licensed partners, and a regulator who knows your name.
+
+## What 2026 actually changed: the regulators started writing
+
+Something genuinely is different this year, and it isn't the venture money. It's paperwork.
+
+Nigeria's central bank ordered banks to close crypto-linked accounts in February 2021. Five years later its Payments System Vision 2028 [proposes to license](https://techcabal.com/2026/06/15/how-stablecoins-became-part-of-nigerias-central-banks-plan-for-payments/) "fully fiat-collateralised stablecoins as monetary instruments," with 100% high-quality reserves, daily attestations and monthly audits. Proposed is not enacted, and the CBN's monetary-instrument framing sits in open tension with a securities regulator whose 2025 Act pulls virtual-asset providers toward SEC registration. But on March 31, 2026, [the CBN started an AML supervision pilot](https://www.premiumtimesng.com/business/business-news/868626-cbn-commences-pilot-programme-on-flutterwave-paystack-others-to-strengthen-virtual-asset-oversight.html) for six virtual-asset players, and Flutterwave is one of them. A licensed fintech that could not legally touch crypto in 2021 is now inside the supervisor's tent.
+
+This is also the fairest answer to the question the table begs: why has nothing shipped? For a company whose whole business sits on CBN licenses, there was no lawful category to ship INTO. Banks were fenced off from crypto in 2021, the stablecoin framework is still a proposal, the pilot confers no license by its own terms, and no approval for stablecoin settlement has been named anywhere. Read that way, five announcements in thirty-three months look less like a vaporware habit and more like flag-planting ahead of a legal window that is only now creaking open. The receipts test stays the same either way. The window opening is exactly when flags have to become products.
+
+What would Flutterwave actually need to run USDC settlement for a Lagos merchant? None of this is insider knowledge. You can reconstruct the stack from public documents; treat what follows as my reading of them rather than a statement of fact. Its existing licenses, the switching-and-processing license from 2022 plus older PSSP and IMTO permits, cover the naira legs and none of the virtual-asset ones. The stablecoin leg would pull in SEC VASP registration under the 2025 Act, with its incorporation, office and fee requirements, plus whatever license category crystallizes out of the CBN's proposals, for which the pilot seat is the current bridge. Kenya [passed its VASP Act](https://www.centralbank.go.ke/uploads/press_releases/665231223_Public%20Notice%20on%20the%20Virtual%20Assets%20Service%20Providers%20Act%202025.pdf) and then left it in limbo pending implementing regulations, with a compliance deadline in November 2026. Ghana [already requires Bank of Ghana registration](https://www.bog.gov.gh/news/mandatory-registration-of-virtual-asset-service-providers-operating-in-ghana/). Nigeria is the stated first market for the RLUSD rollout, and for USDC nobody has named a market at all.
+
+One more number belongs here, because it disciplines the whole regulatory story: cNGN, the naira stablecoin that launched under the SEC's sandbox in February 2025, had [about ₦2.3 billion in circulation as of June 12, 2026](https://cngn.co/). That is roughly 1.5 million dollars. A regulated framework is necessary. It is nowhere near sufficient.
+
+## The skeptic is mostly right
+
+The strong version of the case against this piece runs like this: an undisclosed-size venture check dressed as infrastructure news is a fair description of the July 7 announcement. Flutterwave's [$3.2 billion Series E valuation](https://www.theblock.co/post/404942/ripple-flutterwave-series-3-2-billion-valuation-rlusd-integration) is roughly flat against 2022, reported secondary trades have run far lower, and the company cut half its staff in Kenya and South Africa in 2025 while its IPO waits on profitability. Circle's one previous African flagship produced a pilot and silence. And as the last two sections argue, the chain layer these deals occupy is a rounding error next to the off-ramp problem. If your read is "nothing happened on July 7," you are closer to right than the headlines were.
+
+Here's what survives the concession. Two issuers paying for position in the same distribution channel within thirty days is a new market fact, not a press release. The regulatory machinery is moving for the first time in five years. So instead of a verdict, I'll give you the falsifiable version, the shipping list I'll be watching:
+
+1. **A product page that takes money.** StableRails graduating from waitlist to general availability, with pricing and API docs.
+2. **A named first market and the licenses that go with it**.
+3. **Circle saying anything at all about this deal**, with detail the press release didn't contain.
+4. **Developer-facing evidence**: USDC settlement endpoints in Flutterwave's public API documentation.
+5. **A volume number anyone can check**, on any of the five rails.
+
+Each of those is a real event that either happens or doesn't. When one does, this piece gets a dated update. Until then, the table stands.
+
+## Default slots now have a market price
+
+I keep coming back to one fact: Ripple and Circle both paid for position in the same African distribution channel, weeks apart. You could read it narrower, as one capital-hungry company selling the same access twice. But even on that reading, two rival issuers decided within a month of each other that African distribution was worth paying for, and that price signal is new. Default slots on African payment rails now carry a market price, and that changes the arithmetic of every rail negotiation on the continent.
+
+I've argued before that Africa's winning play in this cycle is local abstraction, being the plug that connects naira and shilling reality to whichever global rails win, rather than betting the company on any single one. Flutterwave, whatever ships, is running that exact play: five rails announced, defaults rotated, exclusivity given to no one. The same record that reads as vaporware in the table reads as deliberate non-exclusivity from the operator's chair, and the difference between those two readings is receipts, which is exactly why the shipping list matters. The issuers are competing for the socket now. If you operate payments on this continent, that leverage is yours too, and the price of using it is the same discipline this piece applied to Flutterwave. Believe shipping code. Count the receipts. Make them bid.

--- a/src/content/blog.config.ts
+++ b/src/content/blog.config.ts
@@ -1,4 +1,5 @@
 export const popularSlugs = [
+  'the-off-ramp-is-still-the-product',
   'ai-agent-vs-function-crewai',
   'ethereum-l2-reckoning',
   'react-hooks-complete-guide',


### PR DESCRIPTION
New article on the Flutterwave x Ripple/Circle stablecoin deals, plus its popularSlugs entry.

Verify: /blog/the-off-ramp-is-still-the-product renders on the preview deploy (cost-stack image included) and the post leads the popular sidebar.